### PR TITLE
addresses issue #66 and removes button element from download page

### DIFF
--- a/open_trails/functions.py
+++ b/open_trails/functions.py
@@ -111,7 +111,7 @@ def get_sample_uploaded_features(dataset):
 def encode_list(items):
     '''
     '''
-    return '; '.join(items)
+    return '; '.join(map(str,items))
 
 def make_name_trails(segment_features):
     '''

--- a/open_trails/templates/dataset-05-stewards.html
+++ b/open_trails/templates/dataset-05-stewards.html
@@ -67,7 +67,7 @@
                 <h3 class="badge-heading-h3-fix">Download your data in OpenTrails!</h3>
             </div>
             <br>
-            <button><a href="/datasets/{{ dataset.id }}/open-trails.zip"></a>Download open-trails.zip</button>
+            <a href="/datasets/{{ dataset.id }}/open-trails.zip">Download open-trails.zip</a>
             <p>In the .zip file, you'll find the following files:</p>
             <ul>
                 <li><code>trail_segments.geojson</code>, which contains your trail segment geometries</li>


### PR DESCRIPTION
Forcing items in encode_list into strings. It appears that import processes can result in integer values in the items list. EBRPD dataset for example.

Also removing a button element from download page so that downloading data link works.
